### PR TITLE
Improve late initialize in image provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.0-nullsafety.1
+## 0.4.0-nullsafety.2
 
 * Migrate to non-nullable by default.
 

--- a/lib/src/extended_asset_bundle_image_provider.dart
+++ b/lib/src/extended_asset_bundle_image_provider.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 
 import 'extended_image_provider.dart';
 
+// ignore: must_be_immutable
 class ExtendedExactAssetImageProvider extends ExactAssetImage
     with ExtendedImageProvider {
   ExtendedExactAssetImageProvider(
@@ -16,7 +17,7 @@ class ExtendedExactAssetImageProvider extends ExactAssetImage
     double scale = 1.0,
   }) : super(assetName, bundle: bundle, package: package, scale: scale);
 
-  late final ExtendedAssetBundleImageKey _extendedAssetBundleImageKey;
+  late ExtendedAssetBundleImageKey _extendedAssetBundleImageKey;
 
   @override
   Future<AssetBundleImageKey> obtainKey(ImageConfiguration configuration) {
@@ -135,6 +136,7 @@ class ExtendedAssetBundleImageKey extends AssetBundleImageKey {
         assert(name != null),
         assert(scale != null),
         super(bundle: bundle, name: name, scale: scale);
+
   final _Data data;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: extended_image_library
 description: package library for extended_image, extended_text and extended_text_field, provide common base class.
-version: 0.4.0-nullsafety.1
+version: 0.4.0-nullsafety.2
 homepage: https://github.com/fluttercandies/extended_image_library
 
 environment:


### PR DESCRIPTION
`_extendedAssetBundleImageKey` will be updated several times, so removing the `final` initializer.