### PR TITLE
Set header instead of add

### DIFF
--- a/lib/src/_network_image_io.dart
+++ b/lib/src/_network_image_io.dart
@@ -265,7 +265,7 @@ class ExtendedNetworkImageProvider
   Future<HttpClientResponse> _getResponse(Uri resolved) async {
     final HttpClientRequest request = await httpClient.getUrl(resolved);
     headers?.forEach((String name, String value) {
-      request.headers.add(name, value);
+      request.headers.set(name, value);
     });
     final HttpClientResponse response = await request.close();
     if (timeLimit != null) {


### PR DESCRIPTION
Right now, you can't properly override some default headers, since the default value will still be retained. For example, `User-Agent`, the server will receive the a header which looks like `dart:io v2.10, customvalue` rather than just `customvalue`. If we use `set` instead of `add`, we can replace the original value. 