### PR TITLE
Fix socket leak on bad HTTP response code

### DIFF
--- a/lib/src/_network_image_io.dart
+++ b/lib/src/_network_image_io.dart
@@ -227,6 +227,12 @@ class ExtendedNetworkImageProvider
       final Uri resolved = Uri.base.resolve(key.url);
       final HttpClientResponse? response = await _tryGetResponse(resolved);
       if (response == null || response.statusCode != HttpStatus.ok) {
+        if (response != null) {
+          // The network may be only temporarily unavailable, or the file will be
+          // added on the server later. Avoid having future calls to resolve
+          // fail to check the network again.
+          await response.drain<List<int>>(<int>[]);
+        }
         return null;
       }
 


### PR DESCRIPTION
If a response is given with bad HTTP response code, we need to read the body, or else the connection will stay open. If this happens a lot, it will cause a leak and eventually run out of file handles. 
I saw that flutter does this as well in the code this file is based off of. 