### PR TITLE
fix：修复 setState 时，图片闪烁问题

### DIFF
--- a/lib/src/extended_resize_image_provider.dart
+++ b/lib/src/extended_resize_image_provider.dart
@@ -232,6 +232,34 @@ class ExtendedResizeImage extends ImageProvider<_SizeAwareCacheKey>
     final int targetWidth = (ratio * targetHeight).floor();
     return _IntSize(targetWidth, targetHeight);
   }
+
+  @override
+  bool operator ==(dynamic other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is ExtendedResizeImage &&
+        imageProvider == other.imageProvider &&
+        compressionRatio == other.compressionRatio &&
+        maxBytes == other.maxBytes &&
+        width == other.width &&
+        height == other.height &&
+        allowUpscaling == other.allowUpscaling &&
+        cacheRawData == other.cacheRawData &&
+        imageCacheName == other.imageCacheName;
+  }
+
+  @override
+  int get hashCode => hashValues(
+        imageProvider,
+        compressionRatio,
+        maxBytes,
+        width,
+        height,
+        allowUpscaling,
+        cacheRawData,
+        imageCacheName,
+      );
 }
 
 @immutable


### PR DESCRIPTION
**问题**：外部 setState 时，已加载的图片会再次刷新、闪烁。

代码定位到 如果传递了 maxBytes、cacheWidth、cacheHeight等字段，会使用到 ExtendedResizeImage ，内部未实现 == 方法，导致 didUpdateWidget 执行 _resolveImage（）图片再次刷新。