### PR TITLE
Override http header

### DIFF
--- a/lib/src/_network_image_io.dart
+++ b/lib/src/_network_image_io.dart
@@ -272,7 +272,7 @@ class ExtendedNetworkImageProvider
   Future<HttpClientResponse> _getResponse(Uri resolved) async {
     final HttpClientRequest request = await httpClient.getUrl(resolved);
     headers?.forEach((String name, String value) {
-      request.headers.add(name, value);
+      request.headers.set(name, value);
     });
     final HttpClientResponse response = await request.close();
     if (timeLimit != null) {


### PR DESCRIPTION
In most cases, users want to override http headers instead of add.
For example, I try to override UserAgent but the default UA 'Dart/<version> (dart:io)' is still contained.