### PR TITLE
feat: upgrade web depend

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   js: ^0.6.7
   path: ^1.7.0  
   path_provider: ^2.0.1
-  web: ^0.3.0  
+  web: ^0.4.0  
 
 
 


### PR DESCRIPTION
flutter_localizations from flutter 3.16 sdk depend web ^0.4.0
extended_image depend extended_image_library, extended_image_library depend web ^0.3.0
I upgrade dependencie web 0.3.0 to 0.4.0 to resolve conflict with flutter_localizations