### PR TITLE
fix: wasm compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+* Make the package WASM compatible
+
 ## 5.0.0
 
 * Migrate to 3.29.0

--- a/lib/src/network/extended_network_image_provider.dart
+++ b/lib/src/network/extended_network_image_provider.dart
@@ -4,7 +4,7 @@ import 'package:extended_image_library/src/extended_image_provider.dart';
 import 'package:flutter/painting.dart';
 import 'package:http_client_helper/http_client_helper.dart';
 import 'network_image_io.dart'
-    if (dart.library.js_util) 'network_image_web.dart'
+    if (dart.library.js_interop) 'network_image_web.dart'
     as network_image;
 
 /// [NetworkImage]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: extended_image_library
 description: Library that contains common base class for `extended_image`, `extended_text`, and `extended_text_field`.
 repository: https://github.com/fluttercandies/extended_image_library
-version: 5.0.0
+version: 5.0.1
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
A continuation of https://github.com/fluttercandies/extended_image_library/pull/70 that didn't solved the WASM compatibility issue.